### PR TITLE
Add node_modules to includePaths, instead of relative paths

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,7 +3,9 @@ var sass = require('gulp-sass')
 
 gulp.task('compile-sass', function() {
     return gulp.src('wagtailfontawesome/static_src/wagtailfontawesome/scss/**/*.scss')
-        .pipe(sass())
+        .pipe(sass({
+            includePaths: ['node_modules'],
+        }))
         .pipe(gulp.dest('wagtailfontawesome/static/wagtailfontawesome/css'))
 })
 

--- a/wagtailfontawesome/static_src/wagtailfontawesome/scss/wagtailfontawesome.scss
+++ b/wagtailfontawesome/static_src/wagtailfontawesome/scss/wagtailfontawesome.scss
@@ -1,5 +1,5 @@
 $fa-css-prefix: icon-fa;
-@import "../../../../node_modules/font-awesome/scss/font-awesome";
+@import "font-awesome/scss/font-awesome";
 
 .icon[class^="#{$fa-css-prefix}"]:before,
 .icon[class*=" #{$fa-css-prefix}"]:before {


### PR DESCRIPTION
Instead of using a large `../../../../node_modules` import statement, the `node_modules` directory has been added to `includePaths` when compiling the SASS files. This allows including anything from `node_modules` as `@import "package-name/styles.scss";`.

This is much more robust if the source files are ever moved, as well as being easier on the eyes.
