### PR TITLE
Use staticfiles.static() to generate static URLs

### DIFF
--- a/wagtailfontawesome/wagtail_hooks.py
+++ b/wagtailfontawesome/wagtail_hooks.py
@@ -2,14 +2,15 @@ from pkg_resources import parse_version
 
 from django.utils.html import format_html
 from django.conf import settings
+from django.contrib.staticfiles.templatetags.staticfiles import static
 
 from wagtail.wagtailcore import hooks
 from wagtail.wagtailcore import __version__ as WAGTAIL_VERSION
 
 
 def import_wagtailfontawesome_stylesheet():
-    elem = '<link rel="stylesheet" href="%swagtailfontawesome/css/wagtailfontawesome.css">' % settings.STATIC_URL
-    return format_html(elem)
+    return format_html('<link rel="stylesheet" href="{}">',
+                       static('wagtailfontawesome/css/wagtailfontawesome.css'))
 
 # New Wagtail versions support importing CSS throughout the admin.
 # Fall back to the old hook (editor screen only) for older versions.


### PR DESCRIPTION
This properly supports custom static file storage backends that make custom URLs, such as CachedStaticFilesStorage.