### PR TITLE
Support new Wagtail 2.0 module paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,10 @@ If you want to distribute a Wagtail plugin with FontAwesome icons, you can use t
 
 ```python
 from django.apps import apps
-from wagtail.wagtailcore.blocks import StructBlock
+try:
+    from wagtail.core.blocks import StructBlock
+except ImportError:  # fallback for Wagtail <2.0
+    from wagtail.wagtailcore.blocks import StructBlock
 
 
 class BlockquoteBlock(StructBlock):

--- a/wagtailfontawesome/wagtail_hooks.py
+++ b/wagtailfontawesome/wagtail_hooks.py
@@ -4,8 +4,12 @@ from django.utils.html import format_html
 from django.conf import settings
 from django.contrib.staticfiles.templatetags.staticfiles import static
 
-from wagtail.wagtailcore import hooks
-from wagtail.wagtailcore import __version__ as WAGTAIL_VERSION
+try:
+    from wagtail.core import hooks
+    from wagtail import __version__ as WAGTAIL_VERSION
+except ImportError:
+    from wagtail.wagtailcore import hooks
+    from wagtail.wagtailcore import __version__ as WAGTAIL_VERSION
 
 
 def import_wagtailfontawesome_stylesheet():


### PR DESCRIPTION
Various module paths are going to be renamed in Wagtail 2.0, including `wagtail.wagtailcore` -> `wagtail.core` - this PR adds support for the new paths.