### PR TITLE
Generalize description

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ Wagtail FontAwesome
 .. image:: https://img.shields.io/github/license/mashape/apistatus.svg
     :target: https://github.com/alexgleason/wagtailfontawesome/blob/master/LICENSE
 
-Add `FontAwesome 4.7 <https://fontawesome.com/v4.7.0/>`_ icons to StreamField.
+Add `FontAwesome 4.7 <https://fontawesome.com/v4.7.0/>`_ icons to your Wagtail project.
 
 .. image:: https://raw.githubusercontent.com/alexgleason/wagtailfontawesome/master/screenshot.png
     :alt: Screenshot


### PR DESCRIPTION
The line with the proposed change makes it sound like StreamField is the only place the icons can be applied but, of course, other areas where they can be applied are noted further down.  I suggest removing the reference to StreamField in the project's description line.